### PR TITLE
Remove PHP Extensions Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ RUN npm install
 RUN npm run build
 FROM docker.io/dunglas/frankenphp:static-builder-musl-1.7.0 AS builder
 
-# Install php extensions
-RUN install-php-extensions imagick
-
 ENV NO_COMPRESS=1
 
 WORKDIR /go/src/app/dist/app


### PR DESCRIPTION
The imagick php extensions already installed See: https://frankenphp.dev/docs/embed/#php-extensions + https://github.com/php/frankenphp/blob/6be261169a6f43ebcf048273331d7f0f49a08f1b/build-static.sh#L76